### PR TITLE
Capture deploy regions in code - the Dagger pipeline

### DIFF
--- a/INFRASTRUCTURE.md
+++ b/INFRASTRUCTURE.md
@@ -1,8 +1,8 @@
 This app is deployed to Fly.io as 3 instances:
 
-1. 🇺🇸 San Jose
-2. 🇫🇷 Paris
-3. 🇯🇵 Tokyo
+1. 🇺🇸 Sunnyvale or Chicago
+2. 🇫🇷 Paris or 🇳🇱 Amsterdam
+3. 🇸🇬 Singapore
 
 We are doing this for higher availability & lower edge latency. This is what
 that means for our end-users:
@@ -18,8 +18,8 @@ flowchart LR
     
     subgraph Fly.io
         registry_redirect_usa("🇺🇸 registry.dagger.io/engine")
-        registry_redirect_fr("🇫🇷 registry.dagger.io/engine")
-        registry_redirect_jp("🇯🇵 registry.dagger.io/engine")
+        registry_redirect_fr("🇫🇷 🇳🇱 registry.dagger.io/engine")
+        registry_redirect_jp(" 🇸🇬 registry.dagger.io/engine")
     end
 
     subgraph GitHub
@@ -57,8 +57,5 @@ reponsible for testing, building, publishing & deploying the app.
 - `flyctl config save --app dagger-registry-2023-01-23`
 - Make necessary edits to `fly.toml`
 - Deploy app from local: `GITHUB_REF_NAME=main mage all`
-- `flyctl regions add sjc cdg nrt`
-- `flyctl scale 3`
-- `flyctl regions delete lhr`
 - Configure `registry.dagger.io` A & AAAA DNS record - `flyctl ips list`
 - `flyctl certs create registry.dagger.io`

--- a/fly.toml
+++ b/fly.toml
@@ -14,9 +14,6 @@ processes = []
 [env]
   PORT = "8080"
 
-[deploy]
-  strategy = "bluegreen"
-
 [experimental]
   auto_rollback = true
   cmd = ["-repo", "dagger"]

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -3,7 +3,7 @@ module github.com/dagger/registry-redirect/magefiles
 go 1.19
 
 require (
-	dagger.io/dagger v0.4.3
+	dagger.io/dagger v0.4.6
 	github.com/containers/image/v5 v5.23.1
 	github.com/magefile/mage v1.14.0
 )
@@ -14,6 +14,6 @@ require (
 	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.1 // indirect
-	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
-	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.5.0 // indirect
 )

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,5 +1,7 @@
 dagger.io/dagger v0.4.3 h1:rp+Ho/iqLAAkJkn7g9BslS3+FYLrrq1Th9fmgkk3C00=
 dagger.io/dagger v0.4.3/go.mod h1:wr3lf4B+yV0CP2rQlYe5fHt0RgKicy7wxA9rBjxW0nI=
+dagger.io/dagger v0.4.6 h1:1GpHJuGrDcLCCIprLpwTXBpKg8Te/RVIDo1qpzkL/QE=
+dagger.io/dagger v0.4.6/go.mod h1:1nbGnLdIfoBV2ahbQjheI//SNGz+b5q1jqf0A+pJ+Oc=
 github.com/99designs/gqlgen v0.17.2/go.mod h1:K5fzLKwtph+FFgh9j7nFbRUdBKvTcGnsta51fsMTn3o=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Khan/genqlient v0.5.0 h1:TMZJ+tl/BpbmGyIBiXzKzUftDhw4ZWxQZ+1ydn0gyII=
@@ -80,6 +82,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -93,6 +97,8 @@ golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
We want to capture the regions that we deploy to in code, not just the README. We also want to be explicit about how many instances we want per region, otherwise we may end up with multiple instances in e.g. France, and none in the US.

While at it, bump the deps that we care about - esp. latest Dagger.